### PR TITLE
Fix US states names

### DIFF
--- a/resources/state/all.json
+++ b/resources/state/all.json
@@ -7460,7 +7460,7 @@
     {
         "code": "4736286",
         "long": {
-            "default": "Tèxas"
+            "default": "Texas"
         }
     },
     {
@@ -7502,13 +7502,13 @@
     {
         "code": "4971068",
         "long": {
-            "default": "Mêne"
+            "default": "Maine"
         }
     },
     {
         "code": "5001836",
         "long": {
-            "default": "Mich·igan"
+            "default": "Michigan"
         }
     },
     {


### PR DESCRIPTION
There are some important mistakes in the US states names.

Source https://fr.wikipedia.org/wiki/%C3%89tats_des_%C3%89tats-Unis